### PR TITLE
Client cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.3.0](https://github.com/expediagroup/service-client/compare/v1.2.1...v1.3.0) (2019-11-20)
+## [1.3.0](https://github.com/expediagroup/service-client/compare/v1.2.1...v1.3.0) (2019-12-03)
 
 #### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Feature
 
-* Caches a client if one does not already exists
+* Caches a client if one does not already exist
 * Returns a cached client if already generated
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-## [1.2.1](https://github.com/expediagroup/service-client/compare/v1.2.0...v1.2.1) (2019-08-22)
+## [1.3.0](https://github.com/expediagroup/service-client/compare/v1.2.1...v1.3.0) (2019-11-20)
 
+#### Feature
+
+* Caches a client if one does not already exists
+* Returns a cached client if already generated
+
+
+## [1.2.1](https://github.com/expediagroup/service-client/compare/v1.2.0...v1.2.1) (2019-08-22)
 
 #### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ For a more thorough collection of examples see the [examples directory](https://
 
 Returns a new service client instance for `servicename` with optional `overrides` to the global defaults listed above:
 
+*Note: If no `overrides` are provided, when a service client instance is created for a `servicename` it will be stored in a cache.  That instance will be returned instead of creating a new instance.*
+
 - **protocol** - The protocol to use for the request. Defaults to `"http:"`.
 - **hostname** - The hostname to use for the request. Accepts a `string` or a `function(serviceName, serviceConfig)` that returns a string.
 - **port** - The port number to use for the request.

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,8 @@ const globalConfig = individual('__serviceclientconfig', {
       keepAliveMsecs: 30000
     }
   },
+  // cached client instances
+  clientInstances: {},
   overrides: {
     // service specific overrides
     // consulkey: { protocol, host, port }

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,6 @@ const create = function (servicename, overrides = {}) {
 
 const destroy = function (servicename) {
   delete GlobalConfig.clientInstances[servicename]
-
-  return
 }
 
 const use = function (plugins = []) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,17 @@ const create = function (servicename, overrides = {}) {
     config.agent = Agent.create(config.protocol, config)
   }
 
-  if (typeof GlobalConfig.clientInstances[servicename] === 'undefined') {
+  // If overrides are passed do not cache the client
+  if (Object.keys(overrides).length) {
+    const client = new Client(servicename, config)
+
+    debug('create(): created client id %s for service %s', client.id, servicename)
+
+    return client
+  }
+
+  // If the client is not already cached create an instance and cache
+  if (!Object.keys(overrides).length && typeof GlobalConfig.clientInstances[servicename] === 'undefined') {
     GlobalConfig.clientInstances[servicename] = new Client(servicename, config)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ const create = function (servicename, overrides = {}) {
   }
 
   // If the client is not already cached create an instance and cache
-  if (!Object.keys(overrides).length && typeof GlobalConfig.clientInstances[servicename] === 'undefined') {
+  if (typeof GlobalConfig.clientInstances[servicename] === 'undefined') {
     GlobalConfig.clientInstances[servicename] = new Client(servicename, config)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,12 @@ const create = function (servicename, overrides = {}) {
   return config.clientInstances[servicename]
 }
 
+const destroy = function (servicename) {
+  delete GlobalConfig.clientInstances[servicename]
+
+  return
+}
+
 const use = function (plugins = []) {
   if (!Array.isArray(plugins)) {
     plugins = [plugins]
@@ -79,6 +85,7 @@ const mergeConfig = function (externalConfig = {}) {
 // Exported API
 const ServiceClient = {
   create,
+  destroy,
   read: Read,
   use,
   mergeConfig

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ const create = function (servicename, overrides = {}) {
   return GlobalConfig.clientInstances[servicename]
 }
 
-const destroy = function (servicename) {
+const remove = function (servicename) {
   delete GlobalConfig.clientInstances[servicename]
 }
 
@@ -83,7 +83,7 @@ const mergeConfig = function (externalConfig = {}) {
 // Exported API
 const ServiceClient = {
   create,
-  destroy,
+  remove,
   read: Read,
   use,
   mergeConfig

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,13 +38,13 @@ const create = function (servicename, overrides = {}) {
     config.agent = Agent.create(config.protocol, config)
   }
 
-  if (typeof config.clientInstances[servicename] === 'undefined') {
-    config.clientInstances[servicename] = new Client(servicename, config)
+  if (typeof GlobalConfig.clientInstances[servicename] === 'undefined') {
+    GlobalConfig.clientInstances[servicename] = new Client(servicename, config)
   }
 
-  debug('create(): created client id %s for service %s', config.clientInstances[servicename].id, servicename)
+  debug('create(): created client id %s for service %s', GlobalConfig.clientInstances[servicename].id, servicename)
 
-  return config.clientInstances[servicename]
+  return GlobalConfig.clientInstances[servicename]
 }
 
 const destroy = function (servicename) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,11 +38,13 @@ const create = function (servicename, overrides = {}) {
     config.agent = Agent.create(config.protocol, config)
   }
 
-  const client = new Client(servicename, config)
+  if (typeof config.clientInstances[servicename] === 'undefined') {
+    config.clientInstances[servicename] = new Client(servicename, config)
+  }
 
-  debug('create(): created client id %s for service %s', client.id, servicename)
+  debug('create(): created client id %s for service %s', config.clientInstances[servicename].id, servicename)
 
-  return client
+  return config.clientInstances[servicename]
 }
 
 const use = function (plugins = []) {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -89,6 +89,7 @@ describe('client', function () {
     afterEach(() => {
       Object.assign(__serviceclientconfig, suite.originalConfig) // eslint-disable-line no-undef
       process.env = suite.originalEnvVars
+      ServiceClient.destroy('myservice')
     })
 
     it('should throw an error if creating an instance without a service name', async () => {
@@ -197,6 +198,10 @@ describe('client', function () {
   })
 
   describe('service-client request', () => {
+    afterEach(() => {
+      ServiceClient.destroy('myservice')
+    })
+
     it('should throw an error if requesting without an `operation`', async function () {
       const client = ServiceClient.create('myservice', { hostname: 'vrbo.com' })
 
@@ -330,6 +335,10 @@ describe('client', function () {
   })
 
   describe('service-client read', () => {
+    afterEach(() => {
+      ServiceClient.destroy('myservice')
+    })
+
     it('should read the response payload', async function () {
       Nock('http://myservice.service.local:80')
         .get('/v1/test/stuff')
@@ -346,6 +355,10 @@ describe('client', function () {
   })
 
   describe('connectTimeout and circuit breaker', () => {
+    afterEach(() => {
+      ServiceClient.destroy('myservice')
+    })
+
     it('should fail the request because `connectTimeout` is short', async function () {
       const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local', connectTimeout: 1, maxFailures: 1 })
 
@@ -409,6 +422,10 @@ describe('client', function () {
   })
 
   describe('timeout and circuit breaker', () => {
+    afterEach(() => {
+      ServiceClient.destroy('myservice')
+    })
+
     it('should fail the request because `timeout` is short and the circuit breaker should trip', async function () {
       Nock('http://myservice.service.local:80')
         .get('/v1/test/stuff')
@@ -438,6 +455,10 @@ describe('client', function () {
   })
 
   describe('circuit breaker and hooks', () => {
+    afterEach(() => {
+      ServiceClient.destroy('myservice')
+    })
+
     it('should execute `error`, `stats`, and `end` hooks if the circuit breaker is open', async function () {
       Nock('http://myservice.service.local:80')
         .get('/v1/test/stuff')

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -195,6 +195,19 @@ describe('client', function () {
       const SC = require('../../lib/client')
       assert.throws(() => new SC(), 'A service name is required')
     })
+
+    it('should use a cached instance when no overrides provided', () => {
+      __serviceclientconfig.overrides.cachedservice = { hostname: 'cachedservice.service.local' } // eslint-disable-line no-undef
+
+      const client1 = ServiceClient.create('cachedservice')
+      const client2 = ServiceClient.create('cachedservice', {})
+      const client3 = ServiceClient.create('cachedservice', {
+        basePath: '/v1/test'
+      })
+
+      assert.equal(client1, client2, 'client2 is equal to client1 because its pulled from the cache')
+      assert.notEqual(client1, client3, 'client3 provides an override and is a new instance of service client')
+    })
   })
 
   describe('service-client request', () => {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -89,7 +89,7 @@ describe('client', function () {
     afterEach(() => {
       Object.assign(__serviceclientconfig, suite.originalConfig) // eslint-disable-line no-undef
       process.env = suite.originalEnvVars
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should throw an error if creating an instance without a service name', async () => {
@@ -199,7 +199,7 @@ describe('client', function () {
 
   describe('service-client request', () => {
     afterEach(() => {
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should throw an error if requesting without an `operation`', async function () {
@@ -336,7 +336,7 @@ describe('client', function () {
 
   describe('service-client read', () => {
     afterEach(() => {
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should read the response payload', async function () {
@@ -356,7 +356,7 @@ describe('client', function () {
 
   describe('connectTimeout and circuit breaker', () => {
     afterEach(() => {
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should fail the request because `connectTimeout` is short', async function () {
@@ -423,7 +423,7 @@ describe('client', function () {
 
   describe('timeout and circuit breaker', () => {
     afterEach(() => {
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should fail the request because `timeout` is short and the circuit breaker should trip', async function () {
@@ -456,7 +456,7 @@ describe('client', function () {
 
   describe('circuit breaker and hooks', () => {
     afterEach(() => {
-      ServiceClient.destroy('myservice')
+      ServiceClient.remove('myservice')
     })
 
     it('should execute `error`, `stats`, and `end` hooks if the circuit breaker is open', async function () {

--- a/test/unit/hooks/request-context.test.js
+++ b/test/unit/hooks/request-context.test.js
@@ -43,6 +43,7 @@ describe('Using ServiceClient in the context of a Hapi request', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
+    ServiceClient.destroy('myservice')
   })
 
   it('should process requests that may be in flight simultaneously', async function () {

--- a/test/unit/hooks/request-context.test.js
+++ b/test/unit/hooks/request-context.test.js
@@ -43,7 +43,7 @@ describe('Using ServiceClient in the context of a Hapi request', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
-    ServiceClient.destroy('myservice')
+    ServiceClient.remove('myservice')
   })
 
   it('should process requests that may be in flight simultaneously', async function () {

--- a/test/unit/hooks/server-context.test.js
+++ b/test/unit/hooks/server-context.test.js
@@ -31,6 +31,7 @@ describe('Using ServiceClient in the context of a Hapi server', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
+    ServiceClient.destroy('myservice')
   })
 
   it('should pass the server via `context` to the `request` hook', async function () {

--- a/test/unit/hooks/server-context.test.js
+++ b/test/unit/hooks/server-context.test.js
@@ -31,7 +31,7 @@ describe('Using ServiceClient in the context of a Hapi server', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
-    ServiceClient.destroy('myservice')
+    ServiceClient.remove('myservice')
   })
 
   it('should pass the server via `context` to the `request` hook', async function () {

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -29,7 +29,7 @@ describe('Using ServiceClient in a standalone context', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
-    ServiceClient.destroy('myservice')
+    ServiceClient.remove('myservice')
   })
 
   it('should call hooks (successful request)', async function () {

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -29,6 +29,7 @@ describe('Using ServiceClient in a standalone context', () => {
     GlobalConfig.plugins = []
     suite.sandbox.restore()
     suite = null
+    ServiceClient.destroy('myservice')
   })
 
   it('should call hooks (successful request)', async function () {


### PR DESCRIPTION
When using the `.create` method we want to store the created client so if `.create` is called again within the application for the same service it would use the existing instance.

## Description
These changes add `clientInstances` to the global config to store created instances of a client.  When `.create` is invoked it checks to see if an existing client has been created for that service and returns it or creates a new instance and stores it.

## Motivation and Context
This prevents applications from having to maintain a cache of all their created service clients.  It also prevents multiple instances of the same client from being created.

## How Has This Been Tested?
This change has been tested by running the test suite.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
