### PR TITLE
Breaking: Updates dependencies and namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.0.0](https://github.com/expediagroup/service-client/compare/v1.3.0...v2.0.0)
+
+### Breaking
+
+* Utilizes patterns established by the [WHATWG URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api)
+    * basePath should end with a `/`
+    * If a `path` variable has a leading '/', it will override the client's configured `basePath`
+
+
 ## [1.3.0](https://github.com/expediagroup/service-client/compare/v1.2.1...v1.3.0) (2019-12-03)
 
 #### Feature

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Returns a new service client instance for `servicename` with optional `overrides
 - **protocol** - The protocol to use for the request. Defaults to `"http:"`.
 - **hostname** - The hostname to use for the request. Accepts a `string` or a `function(serviceName, serviceConfig)` that returns a string.
 - **port** - The port number to use for the request.
-- **basePath** - The base path used to prefix every request path. This path should begin with a `/`.
+- **basePath** - The base path used to prefix every request path. This path should end with a `/`.
 - **connectTimeout** - The connection timeout. Defaults to `1000`.
 - **maxConnectRetry** - After `connectTimeout` elapses, how many attempts to retry the connection. Defaults to `0`.
 - **timeout** - The number of ms to wait without receiving a response before aborting the request. Defaults to `10000`.
@@ -122,15 +122,15 @@ Returns a promise that resolves into the payload in the form of a Buffer or (opt
     - **timeout** - The number of milliseconds to wait while reading data before
     aborting handling of the response. Defaults to unlimited.
     - **json** - A value indicating how to try to parse the payload as JSON. Defaults to `true`.
-        - **true** - Only try `JSON.parse` if the response indicates a JSON content-type.
+        - **true** - Only try `JSON.parse` if the response indicates a JSON content-type. This is the default value.
         - **false** - Do not try `JSON.parse` on the response at all.
         - **strict** - Same as `true`, except throws an error for non-JSON content-type.
         - **force** - Try `JSON.parse` regardless of the content-type header.
-    - **gunzip** - A value indicating the behavior to adopt when the payload is gzipped. Defaults to `undefined` meaning no gunzipping.
+    - **gunzip** - A value indicating the behavior to adopt when the payload is gzipped. Defaults to `false` meaning no gunzipping.
         - **true** - Only try to gunzip if the response indicates a gzip content-encoding.
         - **false** - Explicitly disable gunzipping.
         - **force** - Try to gunzip regardless of the content-encoding header.
-    - **maxBytes** - The maximum allowed response payload size. Defaults to unlimited.
+    - **maxBytes** - The maximum allowed response payload size. Defaults to `0` (unlimited).
 
 ### `ServiceClient.mergeConfig({})`
 
@@ -159,7 +159,7 @@ An instance returned by `ServiceClient.create()`.
 - **`request(options)`** - Makes an http request.
     - **method** - The HTTP method.
     - **hostPrefix** - A base prefix that gets prepended to the hostname.
-    - **path** - Defaults to `'/'`.
+    - **path** - A leading `'/'` will override the client's configured `basePath`.
     - **queryParams** - Object containing key-value query parameter values.
     - **pathParams** - Object containing key-value path parameters to replace `{someKey}` value in path with.
     - **headers** - Object containing key-value pairs of headers.

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -7,13 +7,13 @@ const ServiceClient = require('../..');
   const client = ServiceClient.create('reqres', {
     protocol: 'https:',
     hostname: 'reqres.in',
-    basePath: '/api'
+    basePath: '/api/'
   })
 
   // Submit a request
   const response = await client.request({
     method: 'GET',
-    path: '/users',
+    path: 'users',
     queryParams: { page: 2 },
     operation: 'GET_users_pg2'
   })

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -19,10 +19,10 @@ limitations under the License.
 const Tls = require('tls')
 const Http = require('http')
 const Https = require('https')
-const Hoek = require('hoek')
+const Hoek = require('@hapi/hoek')
 
 const create = function (protocol, options = {}) {
-  let agentOptions = Hoek.applyToDefaultsWithShallow({}, options.agentOptions || {}, ['secureContext'])
+  let agentOptions = Hoek.applyToDefaults({}, options.agentOptions || {}, { shallow: ['secureContext'] })
 
   if (protocol.indexOf('https') >= 0) {
     // Pre cache secureContext for handshake so it doesn't create one every connect.

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,7 +18,7 @@ limitations under the License.
 
 const Cuid = require('cuid')
 const CircuitBreakerState = require('circuit-state')
-const Hoek = require('hoek')
+const Hoek = require('@hapi/hoek')
 
 const { version } = require('../package')
 const Schema = require('./schema')

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict'
 
-const Hoek = require('hoek')
+const Hoek = require('@hapi/hoek')
 
 const GlobalConfig = require('./config')
 

--- a/lib/http/read.js
+++ b/lib/http/read.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict'
 
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 
 const debug = require('debug')('serviceclient:read')
 

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict'
 
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 const QueryString = require('querystring')
 const Cuid = require('cuid')
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 'use strict'
 
-const Hoek = require('hoek')
+const Hoek = require('@hapi/hoek')
 
 const Agent = require('./agent')
 const Schema = require('./schema')
@@ -28,8 +28,8 @@ const debug = require('debug')('serviceclient:factory')
 
 // Factory for client creation
 const create = function (servicename, overrides = {}) {
-  const base = Hoek.applyToDefaultsWithShallow(GlobalConfig.base, GlobalConfig.overrides[servicename] || {}, ['agent'])
-  const merged = Hoek.applyToDefaultsWithShallow(base, overrides, ['agent'])
+  const base = Hoek.applyToDefaults(GlobalConfig.base, GlobalConfig.overrides[servicename] || {}, { shallow: ['agent'] })
+  const merged = Hoek.applyToDefaults(base, overrides, { shallow: ['agent'] })
 
   const config = Schema.validateCreate(merged)
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -19,16 +19,16 @@ limitations under the License.
 const Http = require('http')
 const Https = require('https')
 const Tls = require('tls')
-const Hoek = require('hoek')
-const Joi = require('joi')
+const Hoek = require('@hapi/hoek')
+const Joi = require('@hapi/joi')
 
 const createSchema = Joi.object({
   // requests
   protocol: Joi.string().valid('http:', 'https:'),
-  hostname: Joi.alternatives().try(Joi.string(), Joi.func()).required(),
+  hostname: Joi.alternatives().try(Joi.string(), Joi.function()).required(),
   regions: Joi.array().items(Joi.string()),
   port: Joi.number(),
-  basePath: Joi.string().default('/').regex(/^\//),
+  basePath: Joi.string().default('/').pattern(/\/$/),
 
   // resiliency
   connectTimeout: Joi.number(),
@@ -39,11 +39,11 @@ const createSchema = Joi.object({
 
   // agent options
   agent: Joi.alternatives([
-    Joi.object().type(Http.Agent),
-    Joi.object().type(Https.Agent)
+    Joi.object().instance(Http.Agent),
+    Joi.object().instance(Https.Agent)
   ]),
   agentOptions: Joi.object({
-    secureContext: Joi.object().type(Tls.createSecureContext().constructor),
+    secureContext: Joi.object().instance(Tls.createSecureContext().constructor),
     secureContextOptions: Joi.object().unknown(true)
   }).unknown(true),
 
@@ -52,7 +52,7 @@ const createSchema = Joi.object({
 }).unknown(true)
 
 const requestDefaults = {
-  path: '/',
+  path: '',
   headers: {},
   read: true,
   readOptions: {
@@ -90,13 +90,13 @@ const requestSchema = Joi.object({
 
 // defaults listed in config.js
 const globalSchema = Joi.object({
-  plugins: Joi.array().items(Joi.func()),
+  plugins: Joi.array().items(Joi.function()),
   base: Joi.object(),
   overrides: Joi.object().pattern(/.+/, Joi.object())
 })
 
 function validate (schema, options) {
-  const validated = Joi.validate(options, schema)
+  const validated = schema.validate(options)
 
   Hoek.assert(!validated.error, validated.error)
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "npm run eslint && npm run nyc",
     "eslint": "eslint lib test",
     "mocha": "mocha test/unit/*.js test/unit/**/*.js",
+    "debug": "node --nolazy --inspect-brk=9229 examples/simple/index.js",
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=lcov --report-dir=docs/reports/coverage npm run mocha",
     "postnyc": "nyc check-coverage --statements 100 --branches 97 --functions 100 --lines 100"
   },
@@ -57,29 +58,29 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^8.5.0",
+    "@hapi/joi": "^16.1.7",
+    "@hapi/wreck": "^16.0.1",
     "circuit-state": "^1.0.0",
     "cuid": "^2.0.0",
     "debug": "^4.0.0",
-    "hoek": "^6.0.0",
-    "individual": "^3.0.0",
-    "joi": "^14.0.0",
-    "wreck": "^14.2.0"
+    "individual": "^3.0.0"
   },
   "devDependencies": {
+    "@hapi/good-console": "^8.0.0",
+    "@hapi/good": "^8.1.1",
+    "@hapi/hapi": "^18.4.0",
     "autocannon": "^3.1.0",
     "chai": "^4.1.2",
-    "eslint": "^5.15.1",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "good": "^8.1.1",
-    "good-console": "^8.0.0",
-    "hapi": "^17.7.0",
+    "eslint": "^5.15.1",
     "mocha": "^6.0.0",
     "nock": "^10.0.0",
-    "nyc": "^13.0.0",
+    "nyc": "^14.1.1",
     "proxyquire": "^2.1.0",
     "sinon": "^7.0.0"
   }

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -3,10 +3,10 @@
 const EventEmitter = require('events')
 const { IncomingMessage } = require('http')
 const Nock = require('nock')
-const Hoek = require('hoek')
+const Hoek = require('@hapi/hoek')
 const { assert } = require('chai')
 const Sinon = require('sinon')
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 
 const ServiceClient = require('../../lib')
 const Hooks = require('../../lib/hooks')
@@ -153,9 +153,9 @@ describe('client', function () {
         .get('/v1/test/stuff')
         .reply(200, { message: 'success' })
 
-      const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local', basePath: '/v1/test' })
+      const client = ServiceClient.create('myservice', { hostname: 'myservice.service.local', basePath: '/v1/test/' })
 
-      const response = await client.request({ method: 'GET', path: '/stuff', operation: 'GET_stuff' })
+      const response = await client.request({ method: 'GET', path: 'stuff', operation: 'GET_stuff' })
 
       assert.ok(response, 'is response.')
       assert.equal(response.statusCode, 200, 'is ok response.')
@@ -172,7 +172,7 @@ describe('client', function () {
         },
         overrides: {
           'myservice': {
-            basePath: '/api',
+            basePath: '/api/',
             hostname: 'myservice-test.us-east-1.aws'
           }
         }
@@ -183,7 +183,7 @@ describe('client', function () {
 
       assert.equal(clientConfig.connectTimeout, 9999, 'client config `connectTimeout` was overridden')
       assert.equal(clientConfig.timeout, 1234, 'client config `timeout` was overridden')
-      assert.equal(clientConfig.basePath, '/api', 'client config `basePath` was overridden')
+      assert.equal(clientConfig.basePath, '/api/', 'client config `basePath` was overridden')
       assert.equal(clientConfig.hostname, 'myservice-test.us-east-1.aws', 'client config `hostname` was overridden')
     })
 
@@ -202,7 +202,7 @@ describe('client', function () {
       const client1 = ServiceClient.create('cachedservice')
       const client2 = ServiceClient.create('cachedservice', {})
       const client3 = ServiceClient.create('cachedservice', {
-        basePath: '/v1/test'
+        basePath: '/v1/test/'
       })
 
       assert.equal(client1, client2, 'client2 is equal to client1 because its pulled from the cache')

--- a/test/unit/hooks/request-context.test.js
+++ b/test/unit/hooks/request-context.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const Nock = require('nock')
 const Sinon = require('sinon')
-const Hapi = require('hapi')
-const HapiRequest = require('hapi/lib/request')
-const Wreck = require('wreck')
+const Nock = require('nock')
+const Hapi = require('@hapi/hapi')
+const HapiRequest = require('@hapi/hapi/lib/request')
+const Wreck = require('@hapi/wreck')
 
 const ServiceClient = require('../../../lib')
 const GlobalConfig = require('../../../lib/config')

--- a/test/unit/hooks/server-context.test.js
+++ b/test/unit/hooks/server-context.test.js
@@ -2,7 +2,7 @@
 
 const Nock = require('nock')
 const Sinon = require('sinon')
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
 
 const ServiceClient = require('../../../lib')
 const GlobalConfig = require('../../../lib/config')

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events')
 const Nock = require('nock')
 const Sinon = require('sinon')
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 const { assert } = require('chai')
 
 const ServiceClient = require('../../../lib')

--- a/test/unit/http/read.test.js
+++ b/test/unit/http/read.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Sinon = require('sinon')
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 const { assert } = require('chai')
 
 const Read = require('../../../lib/http/read')

--- a/test/unit/http/request.test.js
+++ b/test/unit/http/request.test.js
@@ -7,7 +7,7 @@ const Http = require('http')
 const Https = require('https')
 const Nock = require('nock')
 const Sinon = require('sinon')
-const Wreck = require('wreck')
+const Wreck = require('@hapi/wreck')
 const { assert } = require('chai')
 
 const Request = require('../../../lib/http/request')


### PR DESCRIPTION
Updates dependencies and namespaces

## Description
Updates hapi dependencies and namespaces to prefix `@hapi`

Breaking changes:

The [Wreck](https://hapi.dev/family/wreck/?v=16.0.1)  update makes 

1. Leading `'/'` in `path` variables to override the client's configured `basePath`
2. `basePath` should end with a `/`
3. ServiceClient.read(response, [options]) `json` option now defaults to `false` [read more](https://hapi.dev/family/wreck/?v=16.0.1#readresponse-options)

## Motivation and Context
To update to the latest versions of dependencies.

## How Has This Been Tested?
Unit tested

Ran integration tests with basic client calls like `GET` using examples/simple/index.js

To test - pull the branch and run npm run debug

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
