### PR TITLE
Fix: make client caching compatible with older global configs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -45,4 +45,10 @@ const globalConfig = individual('__serviceclientconfig', {
   plugins: []
 })
 
+// Shim for when older versions have instantiated
+// the global config and not this instance.
+if (!globalConfig.clientInstances) {
+  globalConfig.clientInstances = {}
+}
+
 module.exports = globalConfig

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+describe('Global Config', function () {
+  it('should shim `clientInstances` when it does not exist', function () {
+    delete require.cache[require.resolve('../../lib/config')]
+    global.__serviceclientconfig = {
+      base: {},
+      overrides: {},
+      plugins: []
+    }
+
+    const GlobalConfig = require('../../lib/config')
+
+    assert.containsAllKeys(GlobalConfig, ['base', 'clientInstances', 'overrides', 'plugins'])
+  })
+})


### PR DESCRIPTION
## Description
When used in conjunction with dependencies that include an older version of service-client, `clientInstances` may not exist in the global config. This PR fixes that by checking for the existence of `clientInstances` and adding it if not.

```
 UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'token-service' of undefined
```

This PR is for `1.x`. I'll submit an additional PR for master.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

cc @cmoody 