### PR TITLE
Fix: make client caching compatible with older global configs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -45,4 +45,10 @@ const globalConfig = individual('__serviceclientconfig', {
   plugins: []
 })
 
+// Shim for when older versions have instantiated
+// the global config and not this instance.
+if (!globalConfig.clientInstances) {
+  globalConfig.clientInstances = {}
+}
+
 module.exports = globalConfig

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { assert } = require('chai')
+
+describe('Global Config', function () {
+  it('should shim `clientInstances` when it does not exist', function () {
+    delete require.cache[require.resolve('../../lib/config')]
+    global.__serviceclientconfig = {
+      base: {},
+      overrides: {},
+      plugins: []
+    }
+
+    const GlobalConfig = require('../../lib/config')
+
+    assert.containsAllKeys(GlobalConfig, ['base', 'clientInstances', 'overrides', 'plugins'])
+  })
+})


### PR DESCRIPTION
Similar to https://github.com/ExpediaGroup/service-client/pull/34, but for `master`