### PR TITLE
Fix: Assert servicename upon client creation; Include servicename in validation errors;

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -31,10 +31,6 @@ const debug = require('debug')('serviceclient:client')
 
 class ServiceClient {
   constructor (servicename, config = {}) {
-    if (!servicename) {
-      throw new Error('A service name is required')
-    }
-
     // Save some values to the instance
     this._servicename = servicename
     this._config = config
@@ -69,6 +65,8 @@ class ServiceClient {
   async request (opts) {
     const self = this
     const config = self._config
+    const clientId = self._id
+    const servicename = self._servicename
 
     const {
       context,
@@ -88,10 +86,7 @@ class ServiceClient {
       read,
       readOptions,
       plugins
-    } = Schema.validateRequest(opts)
-
-    const clientId = self._id
-    const servicename = self._servicename
+    } = Schema.validateRequest(servicename, opts)
 
     const hooks = await Hooks.init({
       client: self,

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,10 +28,14 @@ const debug = require('debug')('serviceclient:factory')
 
 // Factory for client creation
 const create = function (servicename, overrides = {}) {
+  if (!servicename) {
+    throw new Error('A service name is required')
+  }
+
   const base = Hoek.applyToDefaults(GlobalConfig.base, GlobalConfig.overrides[servicename] || {}, { shallow: ['agent'] })
   const merged = Hoek.applyToDefaults(base, overrides, { shallow: ['agent'] })
 
-  const config = Schema.validateCreate(merged)
+  const config = Schema.validateCreate(servicename, merged)
 
   // istanbul ignore else */
   if (!config.agent) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -103,12 +103,22 @@ function validate (schema, options) {
   return validated.value
 }
 
-function validateCreate (options) {
-  return validate(createSchema, options)
+function validateCreate (servicename, options) {
+  try {
+    return validate(createSchema, options)
+  } catch (err) {
+    err.message = `${err.message}. servicename=${servicename}`
+    throw err
+  }
 }
 
-function validateRequest (options) {
-  return validate(requestSchema, options)
+function validateRequest (servicename, options) {
+  try {
+    return validate(requestSchema, options)
+  } catch (err) {
+    err.message = `${err.message}. servicename=${servicename}`
+    throw err
+  }
 }
 
 function validateGlobalConfig (options) {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -92,19 +92,25 @@ describe('client', function () {
       ServiceClient.remove('myservice')
     })
 
-    it('should throw an error if creating an instance without a service name', async () => {
+    it('should throw an error if creating an instance without a service name', () => {
       assert.throws(function () {
-        ServiceClient.create()
-      })
+        ServiceClient.create(undefined, { hostname: 'foobar' })
+      }, 'A service name is required')
     })
 
-    it('should assign a version to the client', async () => {
+    it('should throw an error if creating an instance without a hostname', () => {
+      assert.throws(function () {
+        ServiceClient.create('example-service')
+      }, '"hostname" is required. servicename=example-service')
+    })
+
+    it('should assign a version to the client', () => {
       const client = ServiceClient.create('myservice', { hostname: 'vrbo.com' })
 
       assert.isDefined(client._version)
     })
 
-    it('should fetch client configuration', async () => {
+    it('should fetch client configuration', () => {
       const client = ServiceClient.create('myservice', {
         hostname: 'vrbo.com',
         plugins: {
@@ -189,11 +195,6 @@ describe('client', function () {
 
     it('should merge an empty external config into the global config without error', function () {
       assert.doesNotThrow(() => ServiceClient.mergeConfig())
-    })
-
-    it('should throw an error when constructor not given a service name', () => {
-      const SC = require('../../lib/client')
-      assert.throws(() => new SC(), 'A service name is required')
     })
 
     it('should use a cached instance when no overrides provided', () => {


### PR DESCRIPTION
## Description
* Assert servicename in Client factory method instead of within the Client constructor.
* Include servicename in validation errors.

cc @kashorn

## Motivation and Context
When some schema validation throws an error, this should resolve the ambiguity with respect to which service is in question.

## How Has This Been Tested?
See modified tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
