### PR TITLE
Feature: Add client config option `hostnameConfig` for passing custom config to a `hostname` resolver function

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Returns a new service client instance for `servicename` with optional `overrides
 *Note: If no `overrides` are provided, when a service client instance is created for a `servicename` it will be stored in a cache.  That instance will be returned instead of creating a new instance.*
 
 - **protocol** - The protocol to use for the request. Defaults to `"http:"`.
-- **hostname** - The hostname to use for the request. Accepts a `string` or a `function(serviceName, serviceConfig)` that returns a string.
+- **hostname** - The hostname to use for the request. Accepts a `string` or a `function(serviceName, hostnameConfig || serviceConfig)` that returns a string.
+- **hostnameConfig** - The object passed to the provided `hostname` resolver function. See `hostname` description above.
 - **port** - The port number to use for the request.
 - **basePath** - The base path used to prefix every request path. This path should end with a `/`.
 - **connectTimeout** - The connection timeout. Defaults to `1000`.

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -11,11 +11,15 @@ const ServiceClient = require('../..');
    * @param {string} serviceName The canonical name of our external service
    * @param {object} hostnameConfig A set of configuration options used to construct a url
    */
-  function hostnameResolver (serviceName, hostnameConfig) {
+  function hostnameResolver (serviceName, hostnameConfig = {}) {
     if (process.env.NODE_ENV === 'production') {
       return `${serviceName}.service.local`
     }
-    const { region, env, segment } = hostnameConfig
+    const {
+      region = process.env.AWS_REGION,
+      env = process.env.DEPLOY_ENV,
+      segment = process.env.AWS_SEGMENT
+    } = hostnameConfig
     return `${serviceName}.${region}.${env}.${segment}.mywebsite.com`
   };
 
@@ -28,9 +32,7 @@ const ServiceClient = require('../..');
     base: {
       hostname: hostnameResolver,
       hostnameConfig: {
-        region: process.env.AWS_REGION,
-        env: process.env.DEPLOY_ENV,
-        segment: process.env.AWS_SEGMENT
+        region: 'us-west-2'
       }
     },
     overrides: {

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -18,7 +18,7 @@ const ServiceClient = require('../..');
     const {
       region = process.env.AWS_REGION,
       env = process.env.DEPLOY_ENV,
-      segment = process.env.AWS_SEGMENT
+      segment = process.env.SEGMENT
     } = hostnameConfig
     return `${serviceName}.${region}.${env}.${segment}.mywebsite.com`
   };

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const ServiceClient = require('../..');
+
+(async function start () {
+  /**
+   * A hostname resolver function.
+   * When the application is deployed to production, return a mesh url.
+   * Otherwise, return a fully qualified url using the provided `region`, `env`, and `segment`.
+   *
+   * @param {string} serviceName The canonical name of our external service
+   * @param {object} hostnameConfig A set of configuration options used to construct a url
+   */
+  function hostnameResolver(serviceName, hostnameConfig) {
+    if (process.env.NODE_ENV === 'production') {
+      // return mesh url
+      return `${serviceName}.service.local`
+    }
+    const { region, env, segment } = hostnameConfig
+    return `${serviceName}.${region}.${env}.${segment}.mywebsite.com`
+  };
+
+  /**
+   * Configure service-client with some base settings and some individual overrides.
+   * This is helpful for organizing configuration in a place separate from where the client is created.
+   */
+  ServiceClient.mergeConfig({
+    base: {
+      hostname: hostnameResolver,
+      hostnameConfig: {
+        region: process.env.AWS_REGION,
+        env: process.env.DEPLOY_ENV,
+        segment: process.env.AWS_SEGMENT
+      }
+    },
+    overrides: {
+      myservice: {
+        protocol: 'https:',
+        basePath: '/api/'
+      }
+    }
+  })
+
+  // Create the ServiceClient instance
+  const client = ServiceClient.create('myservice')
+
+  // Submit a request
+  const response = await client.request({
+    method: 'GET',
+    path: 'users',
+    queryParams: { page: 2 },
+    operation: 'GET_users_pg2'
+  })
+
+  console.log(response.statusCode)
+  console.log(response.payload)
+})()

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -5,11 +5,11 @@ const ServiceClient = require('../..');
 (async function start () {
   /**
    * A hostname resolver function. When the application is deployed
-   * to production, return a mesh url. Otherwise, return a fully
-   * qualified url using the provided `region` and `env`.
+   * to production, return a mesh hostname. Otherwise, return a fully
+   * qualified hostname using the provided `region` and `env`.
    *
    * @param {string} serviceName The canonical name of our external service
-   * @param {object} hostnameConfig A set of configuration options used to construct a url
+   * @param {object} hostnameConfig A set of configuration options used to construct a hostname
    */
   function hostnameResolver (serviceName, hostnameConfig = {}) {
     if (process.env.NODE_ENV === 'production') {

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -4,16 +4,15 @@ const ServiceClient = require('../..');
 
 (async function start () {
   /**
-   * A hostname resolver function.
-   * When the application is deployed to production, return a mesh url.
-   * Otherwise, return a fully qualified url using the provided `region`, `env`, and `segment`.
+   * A hostname resolver function. When the application is deployed
+   * to production, return a mesh url. Otherwise, return a fully
+   * qualified url using the provided `region`, `env`, and `segment`.
    *
    * @param {string} serviceName The canonical name of our external service
    * @param {object} hostnameConfig A set of configuration options used to construct a url
    */
-  function hostnameResolver(serviceName, hostnameConfig) {
+  function hostnameResolver (serviceName, hostnameConfig) {
     if (process.env.NODE_ENV === 'production') {
-      // return mesh url
       return `${serviceName}.service.local`
     }
     const { region, env, segment } = hostnameConfig
@@ -21,8 +20,9 @@ const ServiceClient = require('../..');
   };
 
   /**
-   * Configure service-client with some base settings and some individual overrides.
-   * This is helpful for organizing configuration in a place separate from where the client is created.
+   * Configure service-client with some base settings and some individual
+   * overrides. This is helpful for organizing configuration in a place
+   * separate from where the client is created.
    */
   ServiceClient.mergeConfig({
     base: {

--- a/examples/hostname-resolver/index.js
+++ b/examples/hostname-resolver/index.js
@@ -6,7 +6,7 @@ const ServiceClient = require('../..');
   /**
    * A hostname resolver function. When the application is deployed
    * to production, return a mesh url. Otherwise, return a fully
-   * qualified url using the provided `region`, `env`, and `segment`.
+   * qualified url using the provided `region` and `env`.
    *
    * @param {string} serviceName The canonical name of our external service
    * @param {object} hostnameConfig A set of configuration options used to construct a url
@@ -17,10 +17,9 @@ const ServiceClient = require('../..');
     }
     const {
       region = process.env.AWS_REGION,
-      env = process.env.DEPLOY_ENV,
-      segment = process.env.SEGMENT
+      env = process.env.DEPLOY_ENV
     } = hostnameConfig
-    return `${serviceName}.${region}.${env}.${segment}.mywebsite.com`
+    return `${serviceName}.${region}.${env}.mywebsite.com`
   };
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,7 @@ class ServiceClient {
 
     // Build the base url for this client
     if (typeof config.hostname === 'function') {
-      config.hostname = config.hostname(servicename, config)
+      config.hostname = config.hostname(servicename, config.hostnameConfig || config)
     }
 
     const { protocol, hostname, port, basePath } = config

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -26,6 +26,7 @@ const createSchema = Joi.object({
   // requests
   protocol: Joi.string().valid('http:', 'https:'),
   hostname: Joi.alternatives().try(Joi.string(), Joi.function()).required(),
+  hostnameConfig: Joi.object(),
   regions: Joi.array().items(Joi.string()),
   port: Joi.number(),
   basePath: Joi.string().default('/').pattern(/\/$/),


### PR DESCRIPTION
## Description
This PR adds a client config option `hostnameConfig` to be passed along to the provided `hostname` resolver function. If no `hostnameConfig` option is defined, then the client config is passed instead (the current behavior/backwards compatibility).

## Motivation and Context
We needed a clean way to pass information along to our custom hostname resolver. I could easily just pass arbitrary data to the client config, which would be passed along to the hostname resolver, but that seemed like a messy approach. Having all hostname config data in one object seems like a better way to organize that data.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
