### PR TITLE
Fix: refine request options and query param logic

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -96,11 +96,16 @@ async function init (options) {
       // for the `request` hook, merge and return options data
       if (hookName === 'request') {
         // merge results of returned hook data
-        const finalData = Object.assign({}, data.options, {
-          queryParams: { ...data.options.queryParams },
-          pathParams: { ...data.options.pathParams },
-          headers: { ...data.options.headers }
-        })
+        const finalData = { ...data.options }
+        if (data.options.queryParams) {
+          finalData.queryParams = { ...data.options.queryParams }
+        }
+        if (data.options.pathParams) {
+          finalData.pathParams = { ...data.options.pathParams }
+        }
+        if (data.options.headers) {
+          finalData.headers = { ...data.options.headers }
+        }
 
         results.forEach((result) => {
           Hoek.merge(finalData, result)

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -189,18 +189,16 @@ const create = async function (method, path, options, hooks = {}) {
     return options.pathParams[args[1]] || args[0]
   })
 
-  const hasQueryParams = options.queryParams ? Object.keys(options.queryParams).length > 0 : false
-
-  if (hasQueryParams && path.includes('?')) {
-    const parts = path.split('?')
-    options.queryParams = {
-      ...QueryString.parse(parts[1]),
-      ...options.queryParams
+  if (options.queryParams) {
+    if (path.includes('?')) {
+      let queryStr;
+      [path, queryStr] = path.split('?', 2)
+      options.queryParams = {
+        ...QueryString.parse(queryStr),
+        ...options.queryParams
+      }
     }
-    path = parts[0]
-  }
 
-  if (hasQueryParams) {
     path += `?${QueryString.stringify(options.queryParams)}`
   }
 

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -342,8 +342,14 @@ describe('Using ServiceClient in a standalone context', () => {
       return {
         request () {
           return {
+            queryParams: {
+              fizz: 'buzz-boom'
+            },
+            pathParams: {
+              beep: 'boop-boom'
+            },
             headers: {
-              bar: 'baz'
+              bar: 'baz-boom'
             }
           }
         }
@@ -354,14 +360,35 @@ describe('Using ServiceClient in a standalone context', () => {
       hostname: 'foo.com'
     })
 
-    const requestOptions = { fiz: 'buzz' }
+    const requestOptions = {
+      queryParams: {
+        fizz: 'buzz'
+      },
+      pathParams: {
+        beep: 'boop'
+      },
+      headers: {
+        bar: 'baz'
+      }
+    }
 
     await client.request({
       method: 'GET',
       path: '/get',
       operation: 'get',
-      headers: requestOptions
+      ...requestOptions
     })
-    assert.deepEqual(requestOptions, { fiz: 'buzz' })
+
+    assert.deepEqual(requestOptions, {
+      queryParams: {
+        fizz: 'buzz'
+      },
+      pathParams: {
+        beep: 'boop'
+      },
+      headers: {
+        bar: 'baz'
+      }
+    })
   })
 })


### PR DESCRIPTION
## Description
This change is two things:
* An optimization with how request options are copied. See performance tests [here](https://perf.link/#eyJpZCI6InVpZXp0cG8wbnNtIiwidGl0bGUiOiJNZXJnZSBzdHJhdGVnaWVzIiwiYmVmb3JlIjoiY29uc3QgZGF0YSA9IHtcbiAgb3B0aW9uczoge1xuICAgIHF1ZXJ5UGFyYW1zOiB7aGVsbG86ICd3b3JsZCd9LFxuICAgIHBhdGhQYXJhbXM6IHtoZWxsbzogJ3dvcmxkJ30sXG4gICAgaGVhZGVyczoge2hlbGxvOiAnd29ybGQnfVxuICB9XG59IiwidGVzdHMiOlt7Im5hbWUiOiJCYXNlIiwiY29kZSI6ImNvbnN0IGZpbmFsRGF0YSA9IE9iamVjdC5hc3NpZ24oe30sIGRhdGEub3B0aW9ucywge1xuICBxdWVyeVBhcmFtczogeyAuLi5kYXRhLm9wdGlvbnMucXVlcnlQYXJhbXMgfSxcbiAgcGF0aFBhcmFtczogeyAuLi5kYXRhLm9wdGlvbnMucGF0aFBhcmFtcyB9LFxuICBoZWFkZXJzOiB7IC4uLmRhdGEub3B0aW9ucy5oZWFkZXJzIH1cbn0pIiwicnVucyI6WzMxNzAwMCwxNDY0MDAwLDEwMjAwMDAsOTAwMDAsMTIwNTAwMCw2OTMwMDAsMTQ3OTAwMCwyMTEwMDAsNjA0MDAwLDgyMjAwMCwxNzM0MDAwLDEwNzEwMDAsOTAwMCw5MDUwMDAsMTM3MjAwMCwxMjkzMDAwLDk5NTAwMCw4OTAwMCwxMjE2MDAwLDEyNjkwMDAsOTcwMDAwLDUxNTAwMCw5NTQwMDAsOTY3MDAwLDE0NjYwMDAsNTE1MDAwLDEyNjYwMDAsMjcyMDAwLDUxMzAwMCwyMTUwMDAsMjM5MDAwLDI3ODAwMCwyNDAwMDAsNDU0MDAwLDgwMDAsMzEwMDAsMTYzMDAwLDg5NDAwMCwzODkwMDAsNTg2MDAwLDIyMjAwMCwxMTg4MDAwLDEwODUwMDAsODAwMDAsOTQyMDAwLDE1NzUwMDAsMjgyMDAwLDkyODAwMCwzMDgwMDAsMTM4NTAwMCwxNjgwMDAsNzkzMDAwLDEzNTYwMDAsMjA2MDAwLDk5MDAwMCw3NDQwMDAsNTIwMDAsMzU0MDAwLDEwMjUwMDAsMTExMTAwMCwxMDkyMDAwLDg2NjAwMCw3NjAwMDAsMjA2MDAwLDE0ODAwMCw0NDAwMDAsNjM5MDAwLDMwODAwMCw2MTAwMCw5MjMwMDAsNzcwMDAwLDEyMzkwMDAsMTE3MzAwMCwxMDQ4MDAwLDEzNDAwMDAsOTAwMDAwLDExMzgwMDAsMjE1MDAwLDczNDAwMCwxMjQ1MDAwLDQ2MDAwMCwxNDkwMDAsOTAxMDAwLDE1NzMwMDAsODIxMDAwLDIyODAwMCw2MDgwMDAsNjEyMDAwLDEzMjEwMDAsMTQ2MDAwMCw0NDgwMDAsNjE4MDAwLDQ5MDAwLDUxMTAwMCwzMzUwMDAsMTUzNTAwMCw2MTIwMDAsMjMwMDAwLDYxMDAwLDEyMjcwMDBdLCJvcHMiOjcyNTkxMH0seyJuYW1lIjoiQ2hlY2tpbmcgZm9yIGRlZmluZWQgcGFyYW1zIiwiY29kZSI6ImNvbnN0IGZpbmFsRGF0YSA9IHsuLi5kYXRhLm9wdGlvbnN9O1xuaWYgKGRhdGEub3B0aW9ucy5xdWVyeVBhcmFtcykge1xuICBmaW5hbERhdGEucXVlcnlQYXJhbXMgPSB7Li4uZGF0YS5vcHRpb25zLnF1ZXJ5UGFyYW1zfVxufVxuaWYgKGRhdGEub3B0aW9ucy5wYXRoUGFyYW1zKSB7XG4gIGZpbmFsRGF0YS5wYXRoUGFyYW1zID0gey4uLmRhdGEub3B0aW9ucy5wYXRoUGFyYW1zfVxufVxuaWYgKGRhdGEub3B0aW9ucy5oZWFkZXJzKSB7XG4gIGZpbmFsRGF0YS5oZWFkZXJzID0gey4uLmRhdGEub3B0aW9ucy5oZWFkZXJzfVxufSIsInJ1bnMiOlszMTAwMCwyMTMxMDAwLDI2OTcwMDAsOTI0MDAwLDE2NjkwMDAsMjQ2MjAwMCwyNjAyMDAwLDI3NDgwMDAsNzQ4MDAwLDEyNTkwMDAsODM2MDAwLDI1OTEwMDAsMjg0MDAwLDM0MTAwMDAsMTA4NTAwMCwyMDM0MDAwLDk0ODAwMCwzNDgwMDAwLDQyMTAwMCwzMDAwLDIxMjAwMCwxODc0MDAwLDIzMDIwMDAsMTk3NzAwMCwwLDIxMTgwMDAsNzIzMDAwLDE0MjUwMDAsMTg3ODAwMCwxMDAwLDE0MTQwMDAsMzI2MDAwLDI3MTUwMDAsMzI0MTAwMCwyNTAwMDAsMTc3NTAwMCwxOTMxMDAwLDExOTQwMDAsMjQ4OTAwMCwyMDI0MDAwLDczMjAwMCwyODY5MDAwLDIyMzEwMDAsMjMwNTAwMCwyNjM0MDAwLDE4NTAwMDAsMjMyOTAwMCwyMTU4MDAwLDEwNTcwMDAsMjAyMDAwLDI4NzEwMDAsMzUwMDAsMzUzMjAwMCwxMjY0MDAwLDMyNzcwMDAsMjE0MDAwLDEzMzAwMCwzMzAzMDAwLDM0MTAwMCwyMDcwMDAwLDMzNDUwMDAsMTMzMjAwMCwyMjM1MDAwLDExNjUwMDAsMjUxMDAwMCwyMjUwMDAsMjYxMDAwLDMyODAwMDAsMjExMDAwMCwyMTAwMDAsMzQwMDAsMTgyNDAwMCwzMDAxMDAwLDMzNjUwMDAsNzA4MDAwLDI0MDUwMDAsMjM2MDAwLDI4OTQwMDAsMTEyMzAwMCwxMTY3MDAwLDM1NTYwMDAsMzQ5MDAwLDMzODAwMCwyNDAwMDAsMTUwMDAwMCwyNzMwMDAsMzA0MDAwMCwyOTYxMDAwLDI1MjQwMDAsMTg5NDAwMCwyMzM3MDAwLDI1MTYwMDAsNTA1MDAwLDMyNTIwMDAsMjU5MTAwMCw0OTcwMDAsMzMzMjAwMCwxNjkwMDAsMTA5NjAwMCw3NDcwMDBdLCJvcHMiOjE2NDc4NjB9XSwidXBkYXRlZCI6IjIwMjAtMDgtMTRUMTU6MDI6MzAuODc4WiJ9).
* As a result of the change above, a minor refactor in how query params are merged.

## Motivation and Context
Following up on these two PRs:
* https://github.com/ExpediaGroup/service-client/pull/45
* https://github.com/ExpediaGroup/service-client/pull/50

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
