### PR TITLE
Feature: add support for a read hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Feature
+
+* add support for a read hook ([#63](https://github.com/ExpediaGroup/service-client/pull/63))
+
 ## [3.1.0](https://github.com/expediagroup/service-client/compare/v3.0.1...v3.1.0) (2021-09-09)
 
 #### Feature

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ async function plugin({client, context, plugins}) {
          * @param {object} data - data provided to the hook on every request
          * @param {object} data.response - the response received from Wreck after being read
          */
-        async onPostRead(data) {
+        async read(data) {
 
         },
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Service-Client plugins provide the ability to hook into different spots of a req
 Plugins are registered with `ServiceClient.mergeConfig({plugins: []})` or `ServiceClient.use([])` and affect all Service-Client instances created thereafter.
 
 ### Overview
-A plugin exports a function which, when executed, returns an object containing a set of hook functions to be ran during a request's lifecycle. See all available hooks [below](#available-plugins).
+A plugin exports a function which, when executed, returns an object containing a set of hook functions to be run during a request's lifecycle. See all available hooks [below](#available-plugins).
 
 Example:
 ```js
@@ -322,7 +322,7 @@ async function plugin({client, context, plugins}) {
          * This hook is special. The only value that should be returned here is
          * a response object. This is helpful for authentication plugins that
          * want to retry a request if an invalid response was received. A request
-         * made within this hook could return it's response object here.
+         * made within this hook could return its response object here.
          *
          * There's a catch however. Since response objects from multiple hooks
          * cannot be merged, only the first response object will be taken. All
@@ -332,6 +332,24 @@ async function plugin({client, context, plugins}) {
          * @param {object} data.response - the response received from Wreck before being read
          */
         async response(data) {
+
+        },
+
+        /**
+         * This hook is special. This hook behaves just like response but can be used to 
+         * validate data after being read. The only value that should be returned here is
+         * a response object. This is helpful for authentication plugins that
+         * want to retry a request if an invalid response was received. A request
+         * made within this hook could return its response object here.
+         *
+         * There's a catch however. Since response objects from multiple hooks
+         * cannot be merged, only the first response object will be taken. All
+         * other returned responses are discarded.
+         *
+         * @param {object} data - data provided to the hook on every request
+         * @param {object} data.response - the response received from Wreck after being read
+         */
+        async onPostRead(data) {
 
         },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -163,6 +163,11 @@ class ServiceClient {
         await hooks.error({ context, clientId, requestId, ts, servicename, operation, error })
       }
     }
+    if (hooks.onPostRead) {
+      reqHooks.onPostRead = async (id, response, ts = Date.now()) => {
+        return hooks.onPostRead({ context, clientId, requestId, ts, servicename, operation, response })
+      }
+    }
 
     const doRequest = async function () {
       if (self._circuitState.open) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -163,9 +163,9 @@ class ServiceClient {
         await hooks.error({ context, clientId, requestId, ts, servicename, operation, error })
       }
     }
-    if (hooks.onPostRead) {
-      reqHooks.onPostRead = async (id, response, ts = Date.now()) => {
-        return hooks.onPostRead({ context, clientId, requestId, ts, servicename, operation, response })
+    if (hooks.read) {
+      reqHooks.read = async (id, response, ts = Date.now()) => {
+        return hooks.read({ context, clientId, requestId, ts, servicename, operation, response })
       }
     }
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -124,6 +124,14 @@ async function init (options) {
 
         return response
       }
+
+      if (hookName === 'onPostRead') {
+        const response = results.find((result) => result)
+
+        debug('%s(): first result: %j', hookName, response)
+
+        return response
+      }
     }
   })
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -115,7 +115,6 @@ async function init (options) {
 
         return finalData
       } else
-
       // for the `response` hook, return the first non-falsy value
       if (hookName === 'response') {
         const response = results.find((result) => result)
@@ -123,8 +122,8 @@ async function init (options) {
         debug('%s(): first result: %j', hookName, response)
 
         return response
-      }
-
+      } else
+      // for the `read` hook, return the first non-falsy value
       if (hookName === 'read') {
         const response = results.find((result) => result)
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -125,7 +125,7 @@ async function init (options) {
         return response
       }
 
-      if (hookName === 'onPostRead') {
+      if (hookName === 'read') {
         const response = results.find((result) => result)
 
         debug('%s(): first result: %j', hookName, response)

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -138,6 +138,14 @@ const makeRequest = async function (method, path, options, hooks) {
     if (hooks.onPostRead) {
       response = await hooks.onPostRead(options.id, response) || response
     }
+    // because of the retry, the code is not going to hit the read step
+    // which means that the payload will not be initialized. instead of
+    // hacking inside hooks to read there, keep the code together and do it
+    // here
+    // eslint-disable-next-line no-prototype-builtins
+    if (!response.hasOwnProperty('payload')) {
+      response.payload = await Read(response, options.readOptions)
+    }
 
     debug('makeRequest(): payload read')
     oncomplete()

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -133,10 +133,11 @@ const makeRequest = async function (method, path, options, hooks) {
       return response
     }
 
-    response.payload = await Read(response, options.readOptions)
-
-    if (hooks.onPostRead) {
-      response = await hooks.onPostRead(options.id, response) || response
+    if (!response.payload) {
+      response.payload = await Read(response, options.readOptions)
+      if (hooks.read) {
+        response = await hooks.read(options.id, response) || response
+      }
     }
 
     debug('makeRequest(): payload read')

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -135,6 +135,10 @@ const makeRequest = async function (method, path, options, hooks) {
 
     response.payload = await Read(response, options.readOptions)
 
+    if (hooks.onPostRead) {
+      response = await hooks.onPostRead(options.id, response) || response
+    }
+
     debug('makeRequest(): payload read')
     oncomplete()
     return response

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -133,7 +133,7 @@ const makeRequest = async function (method, path, options, hooks) {
       return response
     }
 
-    if (!response.payload) {
+    if (response.payload === undefined) {
       response.payload = await Read(response, options.readOptions)
       if (hooks.read) {
         response = await hooks.read(options.id, response) || response

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -138,14 +138,6 @@ const makeRequest = async function (method, path, options, hooks) {
     if (hooks.onPostRead) {
       response = await hooks.onPostRead(options.id, response) || response
     }
-    // because of the retry, the code is not going to hit the read step
-    // which means that the payload will not be initialized. instead of
-    // hacking inside hooks to read there, keep the code together and do it
-    // here
-    // eslint-disable-next-line no-prototype-builtins
-    if (!response.hasOwnProperty('payload')) {
-      response.payload = await Read(response, options.readOptions)
-    }
 
     debug('makeRequest(): payload read')
     oncomplete()

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -44,7 +44,7 @@ describe('Using ServiceClient in a standalone context', () => {
       error: suite.sandbox.spy(),
       stats: suite.sandbox.spy(),
       end: suite.sandbox.spy(),
-      onPostRead: suite.sandbox.spy()
+      read: suite.sandbox.spy()
     }
     ServiceClient.use(() => {
       return spies
@@ -66,9 +66,9 @@ describe('Using ServiceClient in a standalone context', () => {
     Sinon.assert.notCalled(spies.error) // no error for this test
     Sinon.assert.calledOnce(spies.stats)
     Sinon.assert.calledOnce(spies.end)
-    Sinon.assert.calledOnce(spies.onPostRead)
+    Sinon.assert.calledOnce(spies.read)
 
-    Sinon.assert.callOrder(spies.request, spies.init, spies.socket, spies.response, spies.onPostRead, spies.stats, spies.end)
+    Sinon.assert.callOrder(spies.request, spies.init, spies.socket, spies.response, spies.read, spies.stats, spies.end)
   })
 
   it('should call hooks (error thrown in plugin initialization)', async function () {

--- a/test/unit/hooks/standalone.test.js
+++ b/test/unit/hooks/standalone.test.js
@@ -43,7 +43,8 @@ describe('Using ServiceClient in a standalone context', () => {
       response: suite.sandbox.spy(),
       error: suite.sandbox.spy(),
       stats: suite.sandbox.spy(),
-      end: suite.sandbox.spy()
+      end: suite.sandbox.spy(),
+      onPostRead: suite.sandbox.spy()
     }
     ServiceClient.use(() => {
       return spies
@@ -65,8 +66,9 @@ describe('Using ServiceClient in a standalone context', () => {
     Sinon.assert.notCalled(spies.error) // no error for this test
     Sinon.assert.calledOnce(spies.stats)
     Sinon.assert.calledOnce(spies.end)
+    Sinon.assert.calledOnce(spies.onPostRead)
 
-    Sinon.assert.callOrder(spies.request, spies.init, spies.socket, spies.response, spies.stats, spies.end)
+    Sinon.assert.callOrder(spies.request, spies.init, spies.socket, spies.response, spies.onPostRead, spies.stats, spies.end)
   })
 
   it('should call hooks (error thrown in plugin initialization)', async function () {

--- a/test/unit/http/request.test.js
+++ b/test/unit/http/request.test.js
@@ -213,34 +213,6 @@ describe('request', () => {
     assert.ok(response.payload, 'is body')
   })
 
-  it('should make a successful request with `read: true` - onPostRead', async function () {
-    const readStub = suite.sandbox.stub(Wreck, 'read')
-    readStub.onCall(0).returns(null)
-    readStub.onCall(1).returns({ message: 'success' })
-    const hooks = {
-      onPostRead: () => {
-        return { statusCode: 200 }
-      }
-    }
-    Nock('http://service.local:80')
-      .get('/graphql')
-      .reply(200, {
-        errors: [{
-          message:
-                  'Missing or invalid Bearer token in the Authorization header.',
-          extensions: {
-            code: 'FORBIDDEN'
-          }
-        }
-        ]
-      }
-      )
-
-    const response = await Request('GET', '/graphql', { baseUrl: 'http://service.local:80', read: true }, hooks)
-    assert.equal(response.statusCode, 200, 'is ok')
-    assert.ok(response.payload, 'is body')
-  })
-
   it('should make a successful request without `connectTimeout`', async function () {
     const response = await makeRequest({
       getDeferred: () => Request('GET', '/v1/test/stuff', { baseUrl: 'https://service.local:80', connectTimeout: 0 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
Adding support for a new plugin with new hooks to handle GrapQL 

## Description
The Service Client oAuth expects 401 as the status code, but GraphQL returns 200 status code and adds a message in the errors field of the body. This is per the GraphQL specification. As a result, the Service Client is not sending retry requests to refresh the token. The new code handles the new oAuthGraphQL plugin. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If fixes issues with graphql endpoints in the Expedia Group network. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The code has been unit tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have updated the typings as necessary.
