### PR TITLE
refactor: remove overly strict context types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,5 @@
 import { ResponseObject } from '@hapi/hapi';
-import * as Wreck from '@hapi/wreck';
 import Http from 'http';
-import { Logger } from 'pino';
 import QueryString from 'querystring';
 import * as stream from 'stream';
 
@@ -16,7 +14,7 @@ type Headers = {
 export type ServiceClientOptions = {
     agent?: {[key: string]: string};
     connectTimeout?: number;
-    context?: ServiceRequest;
+    context?: any;
     headers?: Headers;
     hostPrefix?: string;
     maxConnectRetry?: number;
@@ -24,7 +22,7 @@ export type ServiceClientOptions = {
     operation: string;
     path?: string;
     pathParams?: {[key: string]: string};
-    payload?: string | Buffer | Stream.Readable | object;
+    payload?: string | Buffer | stream.Readable | object;
     queryParams?: QueryString.ParsedUrlQueryInput;
     read?: boolean;
     readOptions?: {
@@ -35,23 +33,6 @@ export type ServiceClientOptions = {
     };
     redirects?: number;
     timeout?: number;
-};
-
-export interface ServiceRequest {
-    headers: Headers;
-    logger: Logger;
-    auth: {
-        isAuthenticated: boolean;
-        credentials: {
-            apiToken: string;
-            principalToken: string;
-        };
-    };
-}
-
-export type ServiceContext = {
-    dataSources: {[serviceClient: string]: ClientInstance};
-    request: ServiceRequest;
 };
 
 type ServiceClientResponsePayload = stream.Readable
@@ -72,27 +53,31 @@ export type ClientInstance = {
     }>
 };
 
-export type GlobalConfig = {
-    base?: {
-        // url
-        protocol?: string;
-        // resiliency
-        connectTimeout?: number;
-        maxConnectRetry?: number;
-        timeout?: number;
-        maxFailures?: number; // circuit breaking
-        resetTime?: number; // circuit breaking
-        // agent options
-        agentOptions?: {
-            keepAlive?: boolean;
-            keepAliveMsecs?: number;
-        };
+export type ServiceConfig = {
+    // url
+    protocol?: string;
+    // resiliency
+    connectTimeout?: number;
+    maxConnectRetry?: number;
+    timeout?: number;
+    maxFailures?: number; // circuit breaking
+    resetTime?: number; // circuit breaking
+    // agent options
+    agentOptions?: {
+        keepAlive?: boolean;
+        keepAliveMsecs?: number;
     };
+};
+
+export type ServiceOverrides = Record<string, ServiceConfig>;
+
+export type GlobalConfig = {
+    base?: ServiceConfig;
     plugins?: any[];
-    overrides?: {};
+    overrides?: ServiceOverrides;
 }
 
-export function create(servicename: string, overrides?: {}): ClientInstance;
+export function create(servicename: string, overrides?: ServiceOverrides): ClientInstance;
 
 export function remove(servicename: string): void;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,9 @@
 import { ResponseObject } from '@hapi/hapi';
 import Http from 'http';
+import Https from 'https';
 import QueryString from 'querystring';
 import * as stream from 'stream';
+import { SecureContext, SecureContextOptions } from 'tls';
 
 type Headers = {
     readonly [name: string]:
@@ -54,30 +56,33 @@ export type ClientInstance = {
 };
 
 export type ServiceConfig = {
-    // url
     protocol?: string;
-    // resiliency
+    hostname?: string;
+    hostnameConfig?: any,
+    port?: number;
+    basePath?: string;
     connectTimeout?: number;
     maxConnectRetry?: number;
     timeout?: number;
-    maxFailures?: number; // circuit breaking
-    resetTime?: number; // circuit breaking
-    // agent options
+    maxFailures?: number;
+    resetTime?: number;
+    agent?: Http.Agent | Https.Agent;
     agentOptions?: {
         keepAlive?: boolean;
         keepAliveMsecs?: number;
+        secureContext?: SecureContext;
+        secureContextOptions?: SecureContextOptions;
     };
+    plugins?: any;
 };
-
-export type ServiceOverrides = Record<string, ServiceConfig>;
 
 export type GlobalConfig = {
     base?: ServiceConfig;
     plugins?: any[];
-    overrides?: ServiceOverrides;
+    overrides?: Record<string, ServiceConfig>;
 }
 
-export function create(servicename: string, overrides?: ServiceOverrides): ClientInstance;
+export function create(servicename: string, overrides?: ServiceConfig): ClientInstance;
 
 export function remove(servicename: string): void;
 


### PR DESCRIPTION
## Description

The TypeScript types for the context option added in #61 are overly strict. The context option is merely passed through to plugins. This library makes no use of it directly, so the typings do not need to be strict.

Additionally, the overrides structure is currently set to any non-nullable value, so some types for that are added here.

## Motivation and Context

Consumers of this library who use context and TypeScript are forced to either unnecessarily conform to the types defined here (which depend on hapi, pino, and a proprietary auth structure) or disable TypeScript by other means.

## How Has This Been Tested?

Used the new definitions in a private project that uses service-client and TypeScript compilation was still successful.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the typings as necessary.
