### PR TITLE
chore: ignore eslint-plugin-n major change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       # Ignore Hapi major updates
       - dependency-name: "@hapi/hapi"
         update-types: ["version-update:semver-major"]
+      # Ignore Node plugin for ESLint
+      - dependency-name: "eslint-plugin-n"
+        update-types: ["version-update:semver-major"]
       # Ignore Semantic Release major updates
       - dependency-name: "semantic-release"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description
Prevent Dependabot major changes for `eslint-plugin-n`, since it drops support for Node.js v14 at [v16.0.0](https://github.com/eslint-community/eslint-plugin-n/releases/tag/16.0.0) release.